### PR TITLE
Handling pre-installed packages

### DIFF
--- a/bin/pkg-version
+++ b/bin/pkg-version
@@ -25,6 +25,11 @@ function findDeps(part) {
 function getActualVersion(name) {
   var currentSrc = path.resolve(dir, name, 'package.json');
   var parentSrc = path.resolve(dir, '../..', name, 'package.json');
+  /*
+      Node looks for the package all up the tree. 
+      require.resolve will return this path without actually loading the package.
+  */
+  var treeSrc =  require.resolve(name);
   var pkg;
   // Check in directory requested
   if (fs.existsSync(currentSrc)) {
@@ -33,6 +38,17 @@ function getActualVersion(name) {
   // Check in parent directory for case of peerDependencies
   else if (fs.existsSync(parentSrc)) {
     pkg = require(parentSrc);
+  }
+  else if(fs.existsSync(treeSrc)) {
+    /*
+      require.resolve() will return path for index.js of the package.
+      Using regex to get to package.json of package.
+    */
+    var reg = new RegExp(name+'.*');
+    var replacing_string = name+'/'+'package.json';
+    var actualPath = treeSrc.replace(reg,replacing_string);
+    if(fs.existsSync(actualPath))
+     pkg = require(actualPath);
   }
   return pkg ? pkg.version : '';
 }


### PR DESCRIPTION
Handling the case where packages are installed in directories up the tree. 

**Issue:**
For instance, my node packages are installed in directory '/home/username/', and my project directory is '/home/username/abc/def/'.
When I run the pkg-version in my project directory, it returns no data about actual version. 
**Approach used to solve this:**
I am using require.resolve. This will just give me a resolved path where the package is actually picked from, without actually loading the module. 
Let me know of any concerns. 
